### PR TITLE
Correct the signature of FBiOSTargetCommandForwarder::forwarderWithTa…

### DIFF
--- a/FBControlCore/Commands/FBiOSTargetCommandForwarder.h
+++ b/FBControlCore/Commands/FBiOSTargetCommandForwarder.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param commandClasses the classes to forward to.
  @param statefulCommands A set of stateful command class names that should be memoized.
  */
-+ (instancetype)forwarderWithTarget:(id<FBiOSTarget>)target commandClasses:(NSArray<Class> *)commandClasses statefulCommands:(NSSet<NSString *> *)statefulCommands;
++ (instancetype)forwarderWithTarget:(id<FBiOSTarget>)target commandClasses:(NSArray<Class> *)commandClasses statefulCommands:(NSSet<Class> *)statefulCommands;
 
 @end
 


### PR DESCRIPTION
…rget

Summary:
I broke video recording through fbxctest with D20143951 while getting RTC's iOS
stack to build with Clang 10.  D20179404 fixed video recording but re-broke our
stack.  This diff is an attempt to fix both scenarios.

By searching our code for `statefulCommands`, it looks to me like the original
problem is actually that the declaration of `forwarderWithTarget` doesn't match
its implementation so I've made them match by changing the declaration.

Reviewed By: superb

Differential Revision: D20181919

fbshipit-source-id: c03eeb5573f810de4bc51f9802317b68f6afaad5

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/master/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/idb, and link to your PR here.)
