### PR TITLE
Wait for app under test to exit before collecting coverage

### DIFF
--- a/XCTestBootstrap/Reporters/FBJSONTestReporter.m
+++ b/XCTestBootstrap/Reporters/FBJSONTestReporter.m
@@ -198,6 +198,11 @@ static inline NSString *FBFullyFormattedXCTestName(NSString *className, NSString
   [self.events addObject:event];
 }
 
+- (void)appUnderTestExited
+{
+}
+
+
 #pragma mark Event Synthesis
 
 - (NSString *)noStartOfTestPlanErrorMessage

--- a/XCTestBootstrap/Reporters/FBXCTestReporter.h
+++ b/XCTestBootstrap/Reporters/FBXCTestReporter.h
@@ -40,6 +40,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)didFinishExecutingTestPlan;
 
+
+/**
+ Called when the app under test exists
+ */
+- (void)appUnderTestExited;
+
 /**
  Called when the Test Suite has started.
 

--- a/XCTestBootstrap/Reporters/FBXCTestReporterAdapter.m
+++ b/XCTestBootstrap/Reporters/FBXCTestReporterAdapter.m
@@ -74,6 +74,12 @@
   [_reporter didFinishExecutingTestPlan];
 }
 
+- (void)appUnderTestExited {
+  if ([_reporter respondsToSelector:@selector(appUnderTestExited)]) {
+    [_reporter appUnderTestExited];
+  }
+}
+
 - (void)testManagerMediator:(FBTestManagerAPIMediator *)mediator testCase:(NSString *)testClass method:(NSString *)method willStartActivity:(FBActivityRecord *)activity
 {
   if ([_reporter respondsToSelector:@selector(testCase:method:willStartActivity:)]) {

--- a/XCTestBootstrap/Strategies/FBXCTestRunStrategy.m
+++ b/XCTestBootstrap/Strategies/FBXCTestRunStrategy.m
@@ -88,6 +88,11 @@
         logger:self.logger
         testedApplicationAdditionalEnvironment:runnerConfiguration.testedApplicationAdditionalEnvironment];
 
+      // Add callback for when the app under test exists
+      [[applicationProcess exitCode] onQueue:self.iosTarget.workQueue doOnResolved:^(NSNumber * _) {
+        [self.reporter appUnderTestExited];
+      }];
+
       return [[testManager
         connect]
         onQueue:self.iosTarget.workQueue fmap:^(FBTestManagerResult *result) {

--- a/XCTestBootstrap/TestManager/FBTestManagerTestReporter.h
+++ b/XCTestBootstrap/TestManager/FBTestManagerTestReporter.h
@@ -100,6 +100,11 @@ typedef NS_ENUM(NSUInteger, FBTestReportStatus) {
 
 @optional
 /**
+ Called when the app under test has exited
+ */
+- (void)appUnderTestExited;
+
+/**
  Called when a activity has started
 
  @param mediator the test mediator


### PR DESCRIPTION
Summary: The coverage file is only written once the app under test exists so we need to wait for this before reading the file

Differential Revision: D21401813

fbshipit-source-id: 9ed3d71b558c029d44e20510a2c5ac7c8b60fcf0

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/master/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/idb, and link to your PR here.)
